### PR TITLE
fixed typo

### DIFF
--- a/spec/features/users_features_spec.rb
+++ b/spec/features/users_features_spec.rb
@@ -248,7 +248,7 @@ describe 'Feature Test: Go on a Ride', :type => :feature do
     click_link('See attractions')
     click_link("Go on #{@ferriswheel.name}")
     click_button("Go on this ride")
-    expect(page).to have_content("You do not have enough tickets the #{@ferriswheel.name}")
+    expect(page).to have_content("You do not have enough tickets to ride the #{@ferriswheel.name}")
     expect(page).to have_content("Tickets: 1")
   end
 
@@ -259,7 +259,7 @@ describe 'Feature Test: Go on a Ride', :type => :feature do
     click_link("Go on #{@rollercoaster.name}")
     click_button("Go on this ride")
     expect(page).to have_content("You are not tall enough to ride the #{@rollercoaster.name}")
-    expect(page).to have_content("You do not have enough tickets the #{@rollercoaster.name}")
+    expect(page).to have_content("You do not have enough tickets to ride the #{@rollercoaster.name}")
     expect(page).to have_content("Tickets: 1")
   end
 end

--- a/spec/models/ride_spec.rb
+++ b/spec/models/ride_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Ride, :type => :model do
 
   it "has a method 'take_ride' that accounts for the user not having enough tickets" do
     ride = Ride.create(:user_id => user.id, :attraction_id => attraction.id)
-    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets the #{attraction.name}.")
+    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets to ride the #{attraction.name}.")
     expect(user.tickets).to eq(4)
     expect(user.happiness).to eq(3)
     expect(user.nausea).to eq(5)
@@ -58,7 +58,7 @@ RSpec.describe Ride, :type => :model do
   it "has a method 'take_ride' that accounts for the user not being tall enough and not having enough tickets" do
     user.update(:height => 30)
     ride = Ride.create(:user_id => user.id, :attraction_id => attraction.id)
-    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets the #{attraction.name}. You are not tall enough to ride the #{attraction.name}.")
+    expect(ride.take_ride).to eq("Sorry. You do not have enough tickets to ride the #{attraction.name}. You are not tall enough to ride the #{attraction.name}.")
     expect(user.tickets).to eq(4)
     expect(user.happiness).to eq(3)
     expect(user.nausea).to eq(5)


### PR DESCRIPTION
Changed the not enough tickets prompt to match the not tall enough to ride prompt. Before it was Sorry. You do not have enough tickets the #{attraction.name}. You are not tall enough to ride the #{attraction.name}.

I added "to ride". This is for 4 tests in total.